### PR TITLE
fix: pin mparticle deps upper bound in higgs-shop sample

### DIFF
--- a/core-sdk-samples/higgs-shop-sample-app/app/build.gradle.kts
+++ b/core-sdk-samples/higgs-shop-sample-app/app/build.gradle.kts
@@ -104,10 +104,11 @@ dependencies {
     implementation(libs.com.squareup.retrofit)
     implementation(libs.com.squareup.retrofit.converter.gson)
 
-    // mParticle
-    implementation("com.mparticle:android-core:5+")
-    implementation("com.mparticle:android-kit-base:5+")
-    implementation("com.mparticle:android-rokt-kit:5+")
+    // mParticle — bounded upper bound prevents resolving to 6.0.0-rc.1+ on
+    // Maven Central, which removed deprecated symbols. See mparticle-android-sdk#710.
+    implementation("com.mparticle:android-core:[5.0,6.0)")
+    implementation("com.mparticle:android-kit-base:[5.0,6.0)")
+    implementation("com.mparticle:android-rokt-kit:[5.0,6.0)")
 
     // Google Services
     implementation(libs.play.services.ads.identifier)


### PR DESCRIPTION
## Summary

- Replace `5+` selectors with bounded `[5.0,6.0)` ranges for `com.mparticle:android-core`, `android-kit-base`, and `android-rokt-kit` in `core-sdk-samples/higgs-shop-sample-app/app/build.gradle.kts`.

## Why

`com.mparticle:android-core:6.0.0-rc.1` was published to Maven Central on 2026-05-22. Depending on Gradle's selector parsing, `5+` may resolve to higher than 5.x — including the RC, which removed deprecated symbols. The bounded range removes the ambiguity.

See mParticle/mparticle-android-sdk#710 for the broader incident.

## Test plan

- [ ] `./gradlew :core-sdk-samples:higgs-shop-sample-app:app:assembleDebug` resolves a 5.x set of mparticle artifacts (not 6.0.0-rc.1).
- [ ] Sample app still launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)